### PR TITLE
Update maintainers and approvers

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,6 @@ For edit access, get in touch on
 - [Reiley Yang](https://github.com/reyang), Microsoft
 - [Ziqi Zhao](https://github.com/fatsheep9146), Alibaba
 
-
 [Emeritus
 Maintainer/Approver/Triager](https://github.com/open-telemetry/community/blob/main/community-membership.md#emeritus-maintainerapprovertriager):
 

--- a/README.md
+++ b/README.md
@@ -164,20 +164,25 @@ For edit access, get in touch on
 [Maintainers](https://github.com/open-telemetry/community/blob/main/community-membership.md#maintainer)
 ([@open-telemetry/demo-maintainers](https://github.com/orgs/open-telemetry/teams/demo-maintainers)):
 
-- [Austin Parker](https://github.com/austinlparker), Lightstep
-- [Carter Socha](https://github.com/cartersocha), Microsoft
-- [Morgan McLean](https://github.com/mtwo), Splunk
+- [Carter Socha](https://github.com/cartersocha), Lightstep
+- [Juliano Costa](https://github.com/julianocosta89), Dynatrace
+- [Michael Maxwell](https://github.com/mic-max), Microsoft
 - [Pierre Tessier](https://github.com/puckpuck), Honeycomb
 
 [Approvers](https://github.com/open-telemetry/community/blob/main/community-membership.md#approver)
 ([@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers)):
 
-- [Juliano Costa](https://github.com/julianocosta89), Dynatrace
-- [Michael Maxwell](https://github.com/mic-max), Microsoft
+- [Austin Parker](https://github.com/austinlparker), Lightstep
 - [Mikko Viitanen](https://github.com/mviitane), Dynatrace
 - [Penghan Wang](https://github.com/wph95), AppDynamics
 - [Reiley Yang](https://github.com/reyang), Microsoft
 - [Ziqi Zhao](https://github.com/fatsheep9146), Alibaba
+
+
+[Emeritus
+Maintainer/Approver/Triager](https://github.com/open-telemetry/community/blob/main/community-membership.md#emeritus-maintainerapprovertriager):
+
+- [Morgan McLean](https://github.com/mtwo), Splunk
 
 ### Thanks to all the people who have contributed
 


### PR DESCRIPTION
## Changes

- Approver to Maintainer: Juliano, Michael
- Maintainer to Approver: Austin
- Maintainer to Emeritus: Morgan

A maintainer will need to make the accompanying changes to these teams

- https://github.com/orgs/open-telemetry/teams/demo-maintainers
- https://github.com/orgs/open-telemetry/teams/demo-approvers

PS: Is there a way we can just show all the members of a GitHub team nicely? Something similar to the contributors image. I guess it lacks the ability to see names when viewing the markdown though. Just thinking out loud 😂 
